### PR TITLE
Add azure windows runner for pytorch

### DIFF
--- a/.access.yml
+++ b/.access.yml
@@ -86,6 +86,9 @@ policies:
       - admin
       - maintain
       - write
+    users:
+      - wolfv
+      - baszalmstra 
     pull_request: true
 access_control:
   - resource: cirun-openstack-gpu-large

--- a/.access.yml
+++ b/.access.yml
@@ -80,6 +80,13 @@ policies:
       - write
     pull_request: true
     users_from_json: https://raw.githubusercontent.com/Quansight/open-gpu-server/main/access/conda-forge-users.json
+  - id: pytorch-cpu-feedstock-windows-policy
+    repo: pytorch-cpu-feedstock
+    roles:
+      - admin
+      - maintain
+      - write
+    pull_request: true
 access_control:
   - resource: cirun-openstack-gpu-large
     policies:
@@ -125,3 +132,6 @@ access_control:
       - cf-autotick-bot-test-package-policy
       - tensorflow-feedstock-policy
       - xformers-feedstock-policy
+  - resource: cirun-azure-windows-medium
+    policies:
+      - pytorch-cpu-feedstock-windows-policy

--- a/.access.yml
+++ b/.access.yml
@@ -135,6 +135,6 @@ access_control:
       - cf-autotick-bot-test-package-policy
       - tensorflow-feedstock-policy
       - xformers-feedstock-policy
-  - resource: cirun-azure-windows-medium
+  - resource: cirun-azure-windows-2xlarge
     policies:
       - pytorch-cpu-feedstock-windows-policy

--- a/.cirun.global.yml
+++ b/.cirun.global.yml
@@ -117,3 +117,13 @@ runners:
       - linux
       - x64
       - cirun-openstack-cpu-4xlarge
+
+  - name: cirun-azure-windows-medium
+    cloud: azure
+    # 2 cores, 8GB Ram, x64
+    instance_type: Standard_D2s_v3
+    machine_image: "/subscriptions/df033e15-d7e5-43a0-88b8-95b833d272f9/resourceGroups/cirun-runner-images-via-packer/providers/Microsoft.Compute/images/cirun-win22-dev"
+    region: uksouth
+    labels:
+      - windows
+      - cirun-azure-windows-medium

--- a/.cirun.global.yml
+++ b/.cirun.global.yml
@@ -128,4 +128,4 @@ runners:
       - windows
       - cirun-azure-windows-medium
     extra_config:
-      licenseType: Windows_Server      
+      licenseType: Windows_Server

--- a/.cirun.global.yml
+++ b/.cirun.global.yml
@@ -120,8 +120,8 @@ runners:
 
   - name: cirun-azure-windows-2xlarge
     cloud: azure
-    # 2 cores, 8GB Ram, x64
-    instance_type: Standard_D2s_v3
+    # 8 cores, 32GB Ram, x64
+    instance_type: Standard_D8s_v3
     machine_image: "/subscriptions/df033e15-d7e5-43a0-88b8-95b833d272f9/resourceGroups/cirun-runner-images-via-packer/providers/Microsoft.Compute/images/cirun-win22-dev"
     region: uksouth
     labels:

--- a/.cirun.global.yml
+++ b/.cirun.global.yml
@@ -118,7 +118,7 @@ runners:
       - x64
       - cirun-openstack-cpu-4xlarge
 
-  - name: cirun-azure-windows-medium
+  - name: cirun-azure-windows-2xlarge
     cloud: azure
     # 2 cores, 8GB Ram, x64
     instance_type: Standard_D2s_v3
@@ -126,6 +126,6 @@ runners:
     region: uksouth
     labels:
       - windows
-      - cirun-azure-windows-medium
+      - cirun-azure-windows-2xlarge
     extra_config:
       licenseType: Windows_Server

--- a/.cirun.global.yml
+++ b/.cirun.global.yml
@@ -127,3 +127,5 @@ runners:
     labels:
       - windows
       - cirun-azure-windows-medium
+    extra_config:
+      licenseType: Windows_Server      


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

This adds a new configuration for windows runner for [pytorch-cpu-feedstock](https://github.com/conda-forge/pytorch-cpu-feedstock/).

Relevant issues:
- https://github.com/conda-forge/conda-forge.github.io/issues/2169
- https://github.com/Quansight/open-gpu-server/issues/31

cc @jaimergp @isuruf 

@wolfv @baszalmstra can you confirm the following:
- This is only for pytorch feedstock (as in only sponsoring windows runners for pytorch?)
- Runner machine size (`Standard_D2s_v3`) is sufficient, i.e. ~2 cores 8 GB RAM or need a larger runner~ (update: 8 cores and 32GB RAM now)

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
