### PR TITLE
modify machine type

### DIFF
--- a/.access.yml
+++ b/.access.yml
@@ -147,3 +147,6 @@ access_control:
   - resource: cirun-azure-windows-2xlarge
     policies:
       - pytorch-cpu-feedstock-windows-policy
+  - resource: cirun-azure-windows-4xlarge
+    policies:
+      - pytorch-cpu-feedstock-windows-policy

--- a/.cirun.global.yml
+++ b/.cirun.global.yml
@@ -120,13 +120,26 @@ runners:
 
   - name: cirun-azure-windows-2xlarge
     cloud: azure
-    # 8 cores, 32GB Ram, x64
-    instance_type: Standard_D8s_v3
+    # 8 cores, 32GB Ram, 300GB storage, x64
+    instance_type: Standard_D8ads_v5
     machine_image: "/subscriptions/df033e15-d7e5-43a0-88b8-95b833d272f9/resourceGroups/cirun-runner-images-via-packer/providers/Microsoft.Compute/images/cirun-win22-dev"
     region: uksouth
     labels:
       - windows
       - x64
       - cirun-azure-windows-2xlarge
+    extra_config:
+      licenseType: Windows_Server
+
+  - name: cirun-azure-windows-4xlarge
+    cloud: azure
+    # 16 cores, 64GB Ram, 600GB storage, x64
+    instance_type: Standard_D16ads_v5
+    machine_image: "/subscriptions/df033e15-d7e5-43a0-88b8-95b833d272f9/resourceGroups/cirun-runner-images-via-packer/providers/Microsoft.Compute/images/cirun-win22-dev"
+    region: uksouth
+    labels:
+      - windows
+      - x64
+      - cirun-azure-windows-4xlarge
     extra_config:
       licenseType: Windows_Server


### PR DESCRIPTION
The pytorch builds still timed out after 12 hours. 

This PR adds an additional machine type with more cores and memory and changes the type of machines to the newest generation (at roughly the same price). Hopefully changing the machine type will be enough, but otherwise we can try throwing more cores at the problem.

@wolfv @jaimergp 

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
