### PR TITLE
enable regular pytorch contributors to trigger windows builds

### DIFF
--- a/.access.yml
+++ b/.access.yml
@@ -90,6 +90,9 @@ policies:
       - wolfv
       - baszalmstra
       - Tobias-Fischer
+      - hmaarrfk
+      - h-vetinari
+      - isuruf
     pull_request: true
   - id: nodejs-feedstock-policy
     repo: nodejs-feedstock


### PR DESCRIPTION
For work on windows support, it would be helpful if regular contributors from core can trigger builds.

Adding myself, @hmaarrfk & @isuruf for that purpose (please let me know if you don't want this for some reason).

CC @wolfv