### PR TITLE
build tensorflow on the GPU machine

### DIFF
--- a/.access.yml
+++ b/.access.yml
@@ -119,10 +119,12 @@ access_control:
       - libmagma-feedstock-policy
       - pytorch-cpu-feedstock-policy
       - flash-attn-feedstock-policy
+      - tensorflow-feedstock-policy
   - resource: cirun-openstack-gpu-xlarge
     policies:
       - cf-autotick-bot-test-package-policy
       - pytorch-cpu-feedstock-policy
+      - tensorflow-feedstock-policy
   - resource: cirun-openstack-cpu-medium
     policies:
       - cf-autotick-bot-test-package-policy
@@ -140,6 +142,7 @@ access_control:
     policies:
       - cf-autotick-bot-test-package-policy
       - pytorch-cpu-feedstock-policy
+      - tensorflow-feedstock-policy
   - resource: cirun-openstack-gpu-4xlarge
     policies:
       - cf-autotick-bot-test-package-policy


### PR DESCRIPTION
See https://github.com/conda-forge/tensorflow-feedstock/pull/408#issuecomment-2547568914. TensorFlow starts to link `libcuda.so.1` which can be accessible on a GPU machine and inside its docker. I've validated locally and confirmed this can pass the GPU builds.

I am not sure whether `cirun-openstack-gpu-xlarge` is enough so I also request `cirun-openstack-gpu-2xlarge`.