### PR TITLE
Add MacOSX M4 runner for tensorflow

### DIFF
--- a/.access.yml
+++ b/.access.yml
@@ -56,6 +56,13 @@ policies:
       - write
     pull_request: true
     users_from_json: https://raw.githubusercontent.com/Quansight/open-gpu-server/main/access/conda-forge-users.json
+  - id: tensorflow-feedstock-osx-m4-policy
+    repo: tensorflow-feedstock
+    roles:
+      - admin
+      - maintain
+      - write
+    pull_request: true
   - id: mongodb-feedstock-policy
     repo: mongodb-feedstock
     roles:
@@ -81,22 +88,6 @@ policies:
     pull_request: true
     users_from_json: https://raw.githubusercontent.com/Quansight/open-gpu-server/main/access/conda-forge-users.json
   - id: pytorch-cpu-feedstock-windows-policy
-    repo: pytorch-cpu-feedstock
-    roles:
-      - admin
-      - maintain
-      - write
-    users:
-      - wolfv
-      - baszalmstra
-      - Tobias-Fischer
-      - hmaarrfk
-      - h-vetinari
-      - isuruf
-      - mgorny
-      - jeongseok-meta
-    pull_request: true
-  - id: pytorch-cpu-feedstock-osx-m4-policy
     repo: pytorch-cpu-feedstock
     roles:
       - admin
@@ -201,4 +192,4 @@ access_control:
       - onnxruntime-feedstock-windows-policy
   - resource: cirun-macos-m4-large
     policies:
-      - pytorch-cpu-feedstock-osx-m4-policy
+      - tensorflow-feedstock-osx-m4-policy

--- a/.access.yml
+++ b/.access.yml
@@ -62,6 +62,14 @@ policies:
       - admin
       - maintain
       - write
+    users:
+      - h-vetinari
+      - hmaarrfk
+      - wolfv
+      - xhochy
+      - aktech
+      - jaimergp
+      - isuruf
     pull_request: true
   - id: mongodb-feedstock-policy
     repo: mongodb-feedstock

--- a/.access.yml
+++ b/.access.yml
@@ -96,6 +96,22 @@ policies:
       - mgorny
       - jeongseok-meta
     pull_request: true
+  - id: pytorch-cpu-feedstock-osx-m4-policy
+    repo: pytorch-cpu-feedstock
+    roles:
+      - admin
+      - maintain
+      - write
+    users:
+      - wolfv
+      - baszalmstra
+      - Tobias-Fischer
+      - hmaarrfk
+      - h-vetinari
+      - isuruf
+      - mgorny
+      - jeongseok-meta
+    pull_request: true
   - id: nodejs-feedstock-policy
     repo: nodejs-feedstock
     roles:
@@ -183,3 +199,6 @@ access_control:
     policies:
       - pytorch-cpu-feedstock-windows-policy
       - onnxruntime-feedstock-windows-policy
+  - resource: cirun-macos-m4-large
+    policies:
+      - pytorch-cpu-feedstock-osx-m4-policy

--- a/.cirun.global.yml
+++ b/.cirun.global.yml
@@ -146,8 +146,8 @@ runners:
 
   - name: cirun-macos-m4-large
     cloud: on_prem
-    # 8 cores, 8GB Ram, 51GB storage, M4
-    instance_type: 8vcpu-8gb-51gb
+    # 8 cores, 8GB Ram, 75GB storage, M4
+    instance_type: 8vcpu-8gb-75gb
     machine_image: "cirunlabs/macos-sequoia-runner:latest"
     region: RegionOne
     labels:

--- a/.cirun.global.yml
+++ b/.cirun.global.yml
@@ -143,3 +143,14 @@ runners:
       - cirun-azure-windows-4xlarge
     extra_config:
       licenseType: Windows_Server
+
+  - name: cirun-macos-m4-large
+    cloud: on_prem
+    # 8 cores, 8GB Ram, 51GB storage, M4
+    instance_type: 8vcpu-8gb-51gb
+    machine_image: "cirunlabs/macos-sequoia-runner:latest"
+    region: RegionOne
+    labels:
+      - osx
+      - arm64
+      - cirun-macos-m4-large


### PR DESCRIPTION
This adds a new configuration for macos M4 runner for [tensorflow-feedstock](https://github.com/conda-forge/tensorflow-feedstock/).

This is a machine running on scaleway.

cc @wolfv @jaimergp 

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
