### PR TITLE
Give pixi-pack-feedstock access to native macOS runners

### DIFF
--- a/.access.yml
+++ b/.access.yml
@@ -154,6 +154,15 @@ policies:
       - write
     pull_request: true
     users_from_json: https://raw.githubusercontent.com/Quansight/open-gpu-server/main/access/conda-forge-users.json
+  - id: pixi-pack-feedstock-osx-m4-policy
+    repo: pixi-pack-feedstock
+    roles:
+      - admin
+      - maintain
+      - write
+    users:
+      - pavelzw
+    pull_request: true
 access_control:
   - resource: cirun-openstack-gpu-large
     policies:
@@ -222,3 +231,4 @@ access_control:
   - resource: cirun-macos-m4-large
     policies:
       - temporalio-cli-feedstock-osx-m4-policy
+      - pixi-pack-feedstock-osx-m4-policy


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

needed for https://github.com/conda-forge/pixi-pack-feedstock/pull/39


similar to #35 