### PR TITLE
Add large CPU runner for `vllm`

### DIFF
--- a/.access.yml
+++ b/.access.yml
@@ -252,6 +252,7 @@ access_control:
       - nodejs-feedstock-policy
       - flash-attn-feedstock-policy
       - onnxruntime-feedstock-windows-policy
+      - vllm-feedstock-policy
   - resource: cirun-openstack-gpu-2xlarge
     policies:
       - cf-autotick-bot-test-package-policy


### PR DESCRIPTION
Adds a large CPU runner for `vllm` so that wheel compilation uses a less in-demand resource.

- See https://github.com/conda-forge/vllm-feedstock/pull/6#issuecomment-3134725365 for details