### PR TITLE
Allow vllm to run on larger CPU runners

### DIFF
--- a/.access.yml
+++ b/.access.yml
@@ -269,11 +269,13 @@ access_control:
       - jaxlib-feedstock-policy
       - tensorflow-feedstock-policy
       - vtk-m-feedstock-policy
+      - vllm-feedstock-policy
   - resource: cirun-openstack-cpu-4xlarge
     policies:
       - cf-autotick-bot-test-package-policy
       - tensorflow-feedstock-policy
       - ray-packages-feedstock-policy
+      - vllm-feedstock-policy
   - resource: cirun-openstack-cpu-xlarge
     policies:
       - cf-autotick-bot-test-package-policy
@@ -282,6 +284,7 @@ access_control:
       - mongodb-feedstock-policy
       - flash-attn-feedstock-policy
       - onnxruntime-feedstock-windows-policy
+      - vllm-feedstock-policy
   - resource: cirun-azure-windows-2xlarge
     policies:
       - pytorch-cpu-feedstock-windows-policy


### PR DESCRIPTION
- Allows `vllm` to run on larger CPU runners with more RAM. Currently, the runner disconnects from the server because it runs out of RAM.
- Getting access to a larger CPU runner will allow it to build the `vllm` CUDA wheels