### PR TITLE
Add `torchao` feedstock policy to `access.yml`

### DIFF
--- a/.access.yml
+++ b/.access.yml
@@ -228,6 +228,14 @@ policies:
       - write
     pull_request: true
     users_from_json: https://raw.githubusercontent.com/Quansight/open-gpu-server/main/access/conda-forge-users.json
+  - id: torchao-feedstock-policy
+    repo: torchao-feedstock
+    roles:
+      - admin
+      - maintain
+      - write
+    pull_request: true
+    users_from_json: https://raw.githubusercontent.com/Quansight/open-gpu-server/main/access/conda-forge-users.json
 access_control:
   - resource: cirun-openstack-gpu-large
     policies:
@@ -279,6 +287,7 @@ access_control:
       - vtk-m-feedstock-policy
       - vllm-feedstock-policy
       - webkit2gtk4.1-feedstock-policy
+      - torchao-feedstock-policy
   - resource: cirun-openstack-cpu-4xlarge
     policies:
       - cf-autotick-bot-test-package-policy


### PR DESCRIPTION
This PR creates the `cirun` policy for `torchao-feedstock`. Specifically, it grants access to use the `cpu-2xlarge` runner, as needed here: https://github.com/conda-forge/torchao-feedstock/blob/33f30bb46b4e5ab2b31668bdc295c6d7750fcb5e/recipe/conda_build_config.yaml#L2

---
## Context

- Three previous attempts were made to create the PR with the bot, unsuccessfully. See the following PRs for details:
1. https://github.com/conda-forge/admin-requests/pull/1630
2. https://github.com/conda-forge/admin-requests/pull/1631
3. https://github.com/conda-forge/admin-requests/pull/1632

@isuruf

It seems like the previous `admin-requests` jobs ran correctly though:
e.g. for PR 1632:
1. **PR check**: https://github.com/conda-forge/admin-requests/actions/runs/17329785170/job/49202875873
2. **Executing the requested action**: https://github.com/conda-forge/admin-requests/actions/runs/17329803344/job/49202932799
3. **Post-merge cleanup**: https://github.com/conda-forge/admin-requests/actions/runs/17329844451/job/49203064611