### PR TITLE
increase storage for cirun-azure-windows-4xlarge

### DIFF
--- a/.cirun.global.yml
+++ b/.cirun.global.yml
@@ -133,7 +133,7 @@ runners:
 
   - name: cirun-azure-windows-4xlarge
     cloud: azure
-    # 16 cores, 64GB Ram, 600GB storage, x64
+    # 16 cores, 64GB Ram, 1000GB storage, x64
     instance_type: Standard_D16ads_v5
     machine_image: "/subscriptions/df033e15-d7e5-43a0-88b8-95b833d272f9/resourceGroups/cirun-runner-images-via-packer/providers/Microsoft.Compute/images/cirun-win22-dev"
     region: uksouth
@@ -143,6 +143,9 @@ runners:
       - cirun-azure-windows-4xlarge
     extra_config:
       licenseType: Windows_Server
+      storageProfile:
+        osDisk:
+          diskSizeGB: 1000
 
   - name: cirun-macos-m4-large
     cloud: on_prem


### PR DESCRIPTION
Despite being on the biggest `cirun-azure-windows-4xlarge` runner already, https://github.com/conda-forge/pytorch-cpu-feedstock/pull/409 runs out of disk space for the CUDA builds.

Increase the attached storage based on the cirun [docs](https://docs.cirun.io/reference/yaml#custom-disk-size-for-azure), as suggested by @aktech. Given that the existing comment already implies that `Standard_D16ads_v5` has 600GB already (the azure [docs](https://learn.microsoft.com/en-us/azure/virtual-machines/sizes/general-purpose/dasv5-series?tabs=sizestorageremote) only talk about throughput, not capacity), increase it to 1000GB