### PR TITLE
Fix macOS label in `.cirun.global.yml`

### DIFF
--- a/.cirun.global.yml
+++ b/.cirun.global.yml
@@ -154,6 +154,6 @@ runners:
     machine_image: "cirunlabs/macos-sequoia-runner:latest"
     region: RegionOne
     labels:
-      - osx
+      - macOS
       - arm64
       - cirun-macos-m4-large


### PR DESCRIPTION
The label for macOS jobs generated by `conda-smithy` is `macOS` rather than `osx`.  Correct the `.cirun.global.yml` to account for that.

Hopefully fixes https://github.com/conda-forge/conda-smithy/issues/2324

CC @h-vetinari