### PR TITLE
unify pytorch policies

### DIFF
--- a/.access.yml
+++ b/.access.yml
@@ -144,30 +144,26 @@ policies:
     users:
       - pavelzw
     pull_request: true
-  - id: pytorch-cpu-feedstock-cpu-policy
+  # unified policy; not reflecting "-cpu" in feedstock name intentionally
+  - id: pytorch-feedstock-policy
     repo: pytorch-cpu-feedstock
     roles:
       - admin
       - maintain
       - write
+    # manual intersection between pytorch maintainers and people who signed the open-gpu TOS:
+    # users_from_json: https://raw.githubusercontent.com/Quansight/open-gpu-server/main/access/conda-forge-users.json
     users:
-      - wolfv
-      - baszalmstra
       - Tobias-Fischer
       - hmaarrfk
       - h-vetinari
       - isuruf
       - mgorny
       - jeongseok-meta
+      # not on open-gpu-server access list yet
+      # - wolfv
+      # - baszalmstra
     pull_request: true
-  - id: pytorch-cpu-feedstock-gpu-policy
-    repo: pytorch-cpu-feedstock
-    roles:
-      - admin
-      - maintain
-      - write
-    pull_request: true
-    users_from_json: https://raw.githubusercontent.com/Quansight/open-gpu-server/main/access/conda-forge-users.json
   - id: pytorch-scatter-feedstock-policy
     repo: pytorch_scatter-feedstock
     roles:
@@ -283,25 +279,25 @@ access_control:
       - flash-attn-feedstock-policy
       - libmagma-feedstock-policy
       - muscat-split-feedstock-policy
-      - pytorch-cpu-feedstock-gpu-policy
+      - pytorch-feedstock-policy
       - tensorflow-feedstock-policy
       - torchao-feedstock-policy
   - resource: cirun-openstack-gpu-xlarge
     policies:
       - cf-autotick-bot-test-package-policy
-      - pytorch-cpu-feedstock-gpu-policy
+      - pytorch-feedstock-policy
       - tensorflow-feedstock-policy
   - resource: cirun-openstack-gpu-2xlarge
     policies:
       - cf-autotick-bot-test-package-policy
-      - pytorch-cpu-feedstock-gpu-policy
+      - pytorch-feedstock-policy
       - tensorflow-feedstock-policy
       - viskores-feedstock-policy
       - vllm-feedstock-policy
   - resource: cirun-openstack-gpu-4xlarge
     policies:
       - cf-autotick-bot-test-package-policy
-      - pytorch-cpu-feedstock-gpu-policy
+      - pytorch-feedstock-policy
   # Linux: CPU
   - resource: cirun-openstack-cpu-medium
     policies:
@@ -317,7 +313,7 @@ access_control:
       - mongodb-feedstock-policy
       - nodejs-feedstock-policy
       - onnxruntime-feedstock-policy
-      - pytorch-cpu-feedstock-gpu-policy
+      - pytorch-feedstock-policy
       - pytorch-scatter-feedstock-policy
       - tensorflow-feedstock-policy
       - torchao-feedstock-policy
@@ -329,7 +325,7 @@ access_control:
       - flash-attn-feedstock-policy
       - mongodb-feedstock-policy
       - onnxruntime-feedstock-policy
-      - pytorch-cpu-feedstock-gpu-policy
+      - pytorch-feedstock-policy
       - qt-webengine-feedstock-policy
       - tensorflow-feedstock-policy
       - torchao-feedstock-policy
@@ -341,7 +337,7 @@ access_control:
       - cf-autotick-bot-test-package-policy
       - jaxlib-feedstock-policy
       - onnxruntime-feedstock-policy
-      - pytorch-cpu-feedstock-gpu-policy
+      - pytorch-feedstock-policy
       - tensorflow-feedstock-policy
       - torchao-feedstock-policy
       - viskores-feedstock-policy
@@ -366,12 +362,12 @@ access_control:
     policies:
       - libmagma-feedstock-windows-policy
       - onnxruntime-feedstock-policy
-      - pytorch-cpu-feedstock-cpu-policy
+      - pytorch-feedstock-policy
   # OSX
   - resource: cirun-macos-m4-large
     policies:
       - gstreamer-feedstock-osx-m4-policy
       - pixi-pack-feedstock-osx-m4-policy
-      - pytorch-cpu-feedstock-cpu-policy
+      - pytorch-feedstock-policy
       - temporalio-cli-feedstock-osx-m4-policy
       - tensorflow-feedstock-osx-m4-policy


### PR DESCRIPTION
Alternative to #119; I don't think it makes sense to have different policies per resource; any single commit pushed (by someone with the respective rights, i.e. a feedstock maintainer) _must_ be able to trigger runs on all relevant resources.

It is _more_ important IMO that this works cohesively than reusing the "global" access list from https://github.com/Quansight/open-gpu-server/main/access/conda-forge-users.json, or than blindly applying the process from https://github.com/conda-forge/admin-requests/blob/main/examples/example-open-gpu-server.yml for adding resources (which currently is simply unsuited for dealing with multiple resources per feedstock).

Closes #119

CC @jaimergp @mgorny