### PR TITLE
add openvino windows policy

### DIFF
--- a/.access.yml
+++ b/.access.yml
@@ -123,6 +123,18 @@ policies:
       - write
     pull_request: true
     users_from_json: https://raw.githubusercontent.com/Quansight/open-gpu-server/main/access/conda-forge-users.json
+  - id: openvino-feedstock-windows-policy
+    repo: openvino-feedstock
+    roles:
+      - admin
+      - maintain
+      - write
+    users:
+      - artanokhov
+      - culhatsker
+      - mryzhov
+      - h-vetinari
+    pull_request: true
   - id: pixi-pack-feedstock-osx-m4-policy
     repo: pixi-pack-feedstock
     roles:
@@ -342,6 +354,7 @@ access_control:
     policies:
       - libmagma-feedstock-windows-policy
       - onnxruntime-feedstock-policy
+      - openvino-feedstock-windows-policy
       - pytorch-cpu-feedstock-cpu-policy
   - resource: cirun-azure-windows-4xlarge
     policies:


### PR DESCRIPTION
Openvino CI is in a pretty bad state on windows; constantly timing out. It'd be nice to move this over to the prefix server.

@wolfv @baszalmstra, my understanding is still that each individual feedstock added to that server needs approval from prefix; if you tell me that's not the case I'll happily stop pinging you every time something like this comes up 😅 