### PR TITLE
enable pytorch to use larger CPU runners

### DIFF
--- a/.access.yml
+++ b/.access.yml
@@ -329,6 +329,7 @@ access_control:
       - flash-attn-feedstock-policy
       - mongodb-feedstock-policy
       - onnxruntime-feedstock-policy
+      - pytorch-cpu-feedstock-gpu-policy
       - qt-webengine-feedstock-policy
       - tensorflow-feedstock-policy
       - torchao-feedstock-policy
@@ -340,6 +341,7 @@ access_control:
       - cf-autotick-bot-test-package-policy
       - jaxlib-feedstock-policy
       - onnxruntime-feedstock-policy
+      - pytorch-cpu-feedstock-gpu-policy
       - tensorflow-feedstock-policy
       - torchao-feedstock-policy
       - viskores-feedstock-policy


### PR DESCRIPTION
For using CPU runner for non-CUDA builds; c.f. https://github.com/conda-forge/pytorch-cpu-feedstock/pull/332

Yes, the naming with "gpu-policy" makes absolutely no sense, see #121, #122