### PR TITLE
Enable osx Runners for nodejs

### DIFF
--- a/.access.yml
+++ b/.access.yml
@@ -371,6 +371,7 @@ access_control:
   - resource: cirun-macos-m4-large
     policies:
       - gstreamer-feedstock-osx-m4-policy
+      - nodejs-feedstock-policy
       - pixi-pack-feedstock-osx-m4-policy
       - pytorch-cpu-feedstock-cpu-policy
       - temporalio-cli-feedstock-osx-m4-policy


### PR DESCRIPTION
The builds for `osx-arm64` currently fail in 9 out of 10 restarts. 

Also, I was not sure whether this is the right approach or whether extensions also need to go through admin-requests.