### PR TITLE
add osx policy for tinygrad

### DIFF
--- a/.access.yml
+++ b/.access.yml
@@ -224,6 +224,15 @@ policies:
       - write
     pull_request: true
     users_from_json: https://raw.githubusercontent.com/Quansight/open-gpu-server/main/access/conda-forge-users.json
+  - id: tinygrad-feedstock-policy
+    repo: tinygrad-feedstock
+    roles:
+      - admin
+      - maintain
+      - write
+    users:
+      - h-vetinari
+    pull_request: true
   - id: torchao-feedstock-policy
     repo: torchao-feedstock
     roles:
@@ -376,3 +385,4 @@ access_control:
       - pytorch-cpu-feedstock-cpu-policy
       - temporalio-cli-feedstock-osx-m4-policy
       - tensorflow-feedstock-osx-m4-policy
+      - tinygrad-feedstock-policy


### PR DESCRIPTION
Despite "tiny" in the name, https://github.com/tinygrad/tinygrad does a whole lot; notably it has an elaborate JIT-compiler that targets various different things, including METAL on osx; the differences between osx-arm64 and osx-64 are such that the lack of testing is really a massive gap. For example, I'm not sure if https://github.com/tinygrad/tinygrad/issues/13866 is even relevant on osx-arm64, and the [applegpu disassembler](https://github.com/dougallj/applegpu) in https://github.com/conda-forge/tinygrad-feedstock/pull/10 fails on osx-64 with
```
+[MTLLoader sliceIDForDevice:legacyDriverVersion:airntDriverVersion:]:685: failed assertion `Target device architecture is nil'
```

This is a rare case where we need native builds even just for testing.

Companion to https://github.com/conda-forge/admin-requests/pull/1818

