### PR TITLE
Bump Windows VM images to `cirun-win22-20260213-121636`

### DIFF
--- a/.cirun.global.yml
+++ b/.cirun.global.yml
@@ -122,7 +122,7 @@ runners:
     cloud: azure
     # 8 cores, 32GB Ram, 300GB storage, x64
     instance_type: Standard_D8ads_v5
-    machine_image: "/subscriptions/df033e15-d7e5-43a0-88b8-95b833d272f9/resourceGroups/cirun-runner-images-via-packer/providers/Microsoft.Compute/images/cirun-win22-dev"
+    machine_image: "/subscriptions/df033e15-d7e5-43a0-88b8-95b833d272f9/resourceGroups/cirun-runner-images-20260213-121636/providers/Microsoft.Compute/images/cirun-win22-20260213-121636"
     region: uksouth
     labels:
       - windows
@@ -135,7 +135,7 @@ runners:
     cloud: azure
     # 16 cores, 64GB Ram, 1000GB storage, x64
     instance_type: Standard_D16ads_v5
-    machine_image: "/subscriptions/df033e15-d7e5-43a0-88b8-95b833d272f9/resourceGroups/cirun-runner-images-via-packer/providers/Microsoft.Compute/images/cirun-win22-dev"
+    machine_image: "/subscriptions/df033e15-d7e5-43a0-88b8-95b833d272f9/resourceGroups/cirun-runner-images-20260213-121636/providers/Microsoft.Compute/images/cirun-win22-20260213-121636"
     region: uksouth
     labels:
       - windows


### PR DESCRIPTION
Comes from https://github.com/conda-forge/.cirun/pull/145

cc @h-vetinari