### PR TITLE
Bump GPU server VM images

### DIFF
--- a/.cirun.global.yml
+++ b/.cirun.global.yml
@@ -7,7 +7,7 @@ runners:
     # Instance type refers to flavors in openstack
     instance_type: gpu_large
     # The machine image to use for creating VM
-    machine_image: ubuntu-2404-gpu-20260128-080143
+    machine_image: ubuntu-2404-gpu-20260216-160856
     region: RegionOne
     labels:
       - linux
@@ -20,7 +20,7 @@ runners:
     # Instance type refers to flavors in openstack
     instance_type: gpu_xlarge
     # The machine image to use for creating VM
-    machine_image: ubuntu-2404-gpu-20260128-080143
+    machine_image: ubuntu-2404-gpu-20260216-160856
     region: RegionOne
     labels:
       - linux
@@ -33,7 +33,7 @@ runners:
     # Instance type refers to flavors in openstack
     instance_type: gpu_2xlarge
     # The machine image to use for creating VM
-    machine_image: ubuntu-2404-gpu-20260128-080143
+    machine_image: ubuntu-2404-gpu-20260216-160856
     region: RegionOne
     labels:
       - linux
@@ -46,7 +46,7 @@ runners:
     # Instance type refers to flavors in openstack
     instance_type: gpu_4xlarge
     # The machine image to use for creating VM
-    machine_image: ubuntu-2404-gpu-20260128-080143
+    machine_image: ubuntu-2404-gpu-20260216-160856
     region: RegionOne
     labels:
       - linux
@@ -59,7 +59,7 @@ runners:
     # Instance type refers to flavors in openstack
     instance_type: ci_medium
     # The machine image to use for creating VM
-    machine_image: ubuntu-2404-cpu-20260128-075334
+    machine_image: ubuntu-2404-cpu-20260216-155147
     region: RegionOne
     labels:
       - linux
@@ -72,7 +72,7 @@ runners:
     # Instance type refers to flavors in openstack
     instance_type: ci_large
     # The machine image to use for creating VM
-    machine_image: ubuntu-2404-cpu-20260128-075334
+    machine_image: ubuntu-2404-cpu-20260216-155147
     region: RegionOne
     labels:
       - linux
@@ -85,7 +85,7 @@ runners:
     # Instance type refers to flavors in openstack
     instance_type: ci_xlarge
     # The machine image to use for creating VM
-    machine_image: ubuntu-2404-cpu-20260128-075334
+    machine_image: ubuntu-2404-cpu-20260216-155147
     region: RegionOne
     labels:
       - linux
@@ -98,7 +98,7 @@ runners:
     # Instance type refers to flavors in openstack
     instance_type: ci_2xlarge
     # The machine image to use for creating VM
-    machine_image: ubuntu-2404-cpu-20260128-075334
+    machine_image: ubuntu-2404-cpu-20260216-155147
     region: RegionOne
     labels:
       - linux
@@ -111,7 +111,7 @@ runners:
     # Instance type refers to flavors in openstack
     instance_type: ci_4xlarge
     # The machine image to use for creating VM
-    machine_image: ubuntu-2404-cpu-20260128-075334
+    machine_image: ubuntu-2404-cpu-20260216-155147
     region: RegionOne
     labels:
       - linux


### PR DESCRIPTION
Deploys updates from https://github.com/Quansight/open-gpu-server/pull/83 and https://github.com/Quansight/open-gpu-server/pull/85, built in this run: https://github.com/Quansight/open-gpu-server/actions/runs/22069316243