### PR TITLE
Request Windows cirun runner for llama.cpp

### DIFF
--- a/.access.yml
+++ b/.access.yml
@@ -103,6 +103,15 @@ policies:
       - Tobias-Fischer
       - wolfv
     pull_request: true
+  - id: llamacpp-feedstock-policy
+    repo: llama.cpp-feedstock
+    pull_request: true
+    roles:
+      - admin
+      - maintain
+      - write
+    users:
+      - traversaro
   - id: llvmdev-feedstock-policy
     repo: llvmdev-feedstock
     pull_request: true
@@ -396,6 +405,7 @@ access_control:
     policies:
       - clangdev-feedstock-policy
       - libmagma-feedstock-windows-policy
+      - llamacpp-feedstock-policy
       - llvmdev-feedstock-policy
       - onnxruntime-feedstock-policy
       - openvino-feedstock-windows-policy


### PR DESCRIPTION
Windows CUDA jobs are taking more then 6h, see https://github.com/conda-forge/llama.cpp-feedstock/pull/92 . 

I think it would be great if we could use more powerful machines for the Windows build of llama.cpp . fyi @wolfv @baszalmstra

@conda-forge/llama-cpp 


Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
