### PR TITLE
Revert "use Standard_D{8,16}ads_v6 for eastus -ng runners"

### DIFF
--- a/.cirun.global.yml
+++ b/.cirun.global.yml
@@ -4,7 +4,7 @@ runners:
   - name: cirun-azure-windows-2xlarge
     cloud: azure
     # 8 cores, 32GB Ram, 300GB storage, x64
-    instance_type: Standard_D8ads_v6
+    instance_type: Standard_D8ads_v5
     machine_image: "/subscriptions/df033e15-d7e5-43a0-88b8-95b833d272f9/resourceGroups/cirun-runner-images-20260409-051231/providers/Microsoft.Compute/images/cirun-win22-20260409-051231"
     region: eastus
     labels:
@@ -17,7 +17,7 @@ runners:
   - name: cirun-azure-windows-4xlarge
     cloud: azure
     # 16 cores, 64GB Ram, 1000GB storage, x64
-    instance_type: Standard_D16ads_v6
+    instance_type: Standard_D16ads_v5
     machine_image: "/subscriptions/df033e15-d7e5-43a0-88b8-95b833d272f9/resourceGroups/cirun-runner-images-20260409-051231/providers/Microsoft.Compute/images/cirun-win22-20260409-051231"
     region: eastus
     labels:


### PR DESCRIPTION
In contrast to the previous `-ng` images (which we switched to in #186), CI now doesn't start after https://github.com/conda-forge/.cirun/commit/1cfc3fdf8e882db5be7ad659f3c017aaf00956c9

```
{
    "error": "begin create vm: PUT https://management.azure.com/subscriptions/df033e15-d7e5-43a0-88b8-95b833d272f9/resourceGroups/cirun-conda-forge--clangdev-feedstock-f1dce96374/providers/Microsoft.Compute/virtualMachines/cirun-conda-forge--clangdev-feedstock-f1dce96374
              --------------------------------------------------------------------------------
              RESPONSE 400: 400 Bad Request
              ERROR CODE: InvalidParameter
              --------------------------------------------------------------------------------
              {
                "error": {
                  "code": "InvalidParameter",
                  "message": "The VM size 'Standard_D8ads_v6' cannot boot with OS image or disk. Please check that disk controller types supported by the OS image or disk is one of the supported disk controller types for the VM size 'Standard_D8ads_v6'. Please query sku api at https://aka.ms/azure-compute-skus  to determine supported disk controller types for the VM size.",
                  "target": "vmSize"
                }
              }
              --------------------------------------------------------------------------------",
    "runtime": "v2"
}
```

This is a bit strange because it was impossible to _build_ the image on the v5 VMs (after the region change in #179), which had required https://github.com/conda-forge/.cirun/commit/81f37d65225e5f3f7ce84701eac76c5ed6d82eab